### PR TITLE
[UI] : #6, #7 하루 일기 기록(5-3), 대화 기록 조회(5-4)에 해당하는 화면 기본 UI 구성

### DIFF
--- a/app/src/main/java/com/example/durymong/view/do_it/record/DailyDiaryFragment.kt
+++ b/app/src/main/java/com/example/durymong/view/do_it/record/DailyDiaryFragment.kt
@@ -1,0 +1,54 @@
+package com.example.durymong.view.do_it.record
+
+import android.os.Bundle
+import android.text.SpannableString
+import android.text.style.ForegroundColorSpan
+import android.text.style.UnderlineSpan
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import com.example.durymong.databinding.FragmentDoItDailyDiaryBinding
+
+class DailyDiaryFragment: Fragment() {
+    private var _binding: FragmentDoItDailyDiaryBinding? = null
+    private val binding get() = _binding!!
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentDoItDailyDiaryBinding.inflate(layoutInflater)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val dateTextColor = binding.tvDate.currentTextColor
+        val dateText = binding.tvDate.text.toString()
+        val spannableString = SpannableString(dateText)
+
+        //색상 적용
+        spannableString.setSpan(
+            ForegroundColorSpan(dateTextColor),
+            0,
+            dateText.length,
+            SpannableString.SPAN_EXCLUSIVE_EXCLUSIVE
+        )
+        //밑줄 적용
+        spannableString.setSpan(
+            UnderlineSpan(),
+            0,
+            dateText.length,
+            SpannableString.SPAN_EXCLUSIVE_EXCLUSIVE
+        )
+
+        binding.tvDate.text = spannableString
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/app/src/main/java/com/example/durymong/view/do_it/record/DailyRecordFragment.kt
+++ b/app/src/main/java/com/example/durymong/view/do_it/record/DailyRecordFragment.kt
@@ -1,0 +1,27 @@
+package com.example.durymong.view.do_it.record
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import com.example.durymong.databinding.FragmentDoItDailyRecordBinding
+
+class DailyRecordFragment: Fragment() {
+    private var _binding: FragmentDoItDailyRecordBinding? = null
+    private val binding get() = _binding!!
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        _binding = FragmentDoItDailyRecordBinding.inflate(layoutInflater)
+        return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/app/src/main/java/com/example/durymong/view/do_it/record/MonthlyRecordFragment.kt
+++ b/app/src/main/java/com/example/durymong/view/do_it/record/MonthlyRecordFragment.kt
@@ -1,0 +1,26 @@
+package com.example.durymong.view.do_it.record
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import com.example.durymong.databinding.FragmentDoItMonthlyRecordBinding
+
+class MonthlyRecordFragment: Fragment() {
+    private var _binding: FragmentDoItMonthlyRecordBinding? = null
+    private val binding get() = _binding!!
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentDoItMonthlyRecordBinding.inflate(layoutInflater)
+        return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/app/src/main/res/drawable/btn_bg_16_white.xml
+++ b/app/src/main/res/drawable/btn_bg_16_white.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+
+    <solid android:color="@color/white"/>
+    <corners android:radius="16dp"/>
+</shape>

--- a/app/src/main/res/drawable/btn_bg_8_white_purple.xml
+++ b/app/src/main/res/drawable/btn_bg_8_white_purple.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/white"/>
+    <corners android:radius="8dp"/>
+    <stroke android:color="@color/main_purple" android:width="1dp"/>
+</shape>

--- a/app/src/main/res/drawable/et_diary_background.xml
+++ b/app/src/main/res/drawable/et_diary_background.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+
+    <solid android:color="#FAF5FF"/>
+    <corners android:radius="20dp"/>
+</shape>

--- a/app/src/main/res/drawable/ic_do_it_record_arrow_gray2.xml
+++ b/app/src/main/res/drawable/ic_do_it_record_arrow_gray2.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="9dp"
+    android:height="14dp"
+    android:viewportWidth="9"
+    android:viewportHeight="14">
+  <path
+      android:pathData="M0.021,1.871L1.414,0.5L8.021,7L1.414,13.5L0.021,12.13L5.234,7L0.021,1.871Z"
+      android:fillColor="#E4E4E4"
+      android:fillType="evenOdd"/>
+</vector>

--- a/app/src/main/res/drawable/ic_doit_archive.xml
+++ b/app/src/main/res/drawable/ic_doit_archive.xml
@@ -1,0 +1,27 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="20dp"
+    android:height="20dp"
+    android:viewportWidth="20"
+    android:viewportHeight="20">
+  <path
+      android:pathData="M17.5,6.667V17.5H2.5V6.667"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1.41"
+      android:fillColor="#00000000"
+      android:strokeColor="#9D7EF2"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M19.167,2.5H0.833V6.667H19.167V2.5Z"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1.41"
+      android:fillColor="#00000000"
+      android:strokeColor="#9D7EF2"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M8.333,10H11.667"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1.41"
+      android:fillColor="#00000000"
+      android:strokeColor="#9D7EF2"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/layout/fragment_do_it_daily_diary.xml
+++ b/app/src/main/res/layout/fragment_do_it_daily_diary.xml
@@ -37,25 +37,18 @@
             app:layout_constraintTop_toTopOf="@id/cl_date_info_container" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 
-    <View
-        android:id="@+id/v_spacer"
-        android:layout_width="match_parent"
-        android:layout_height="31dp"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/cl_date_info_container" />
 
     <com.google.android.material.card.MaterialCardView
         android:id="@+id/card_character_background"
         android:layout_width="122dp"
         android:layout_height="122dp"
-        android:layout_margin="8dp"
+        android:layout_marginTop="31dp"
         android:backgroundTint="@color/white"
         app:cardCornerRadius="61dp"
         app:cardElevation="8dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/v_spacer">
+        app:layout_constraintTop_toBottomOf="@+id/cl_date_info_container">
 
         <!--    캐릭터 배치     -->
     </com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/layout/fragment_do_it_daily_diary.xml
+++ b/app/src/main/res/layout/fragment_do_it_daily_diary.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:background="#FAFAFA"
+    android:paddingHorizontal="23dp"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/cl_date_info_container"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <TextView
+            android:id="@+id/tv_date"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:fontFamily="@font/suite_bold"
+            android:text="11월 28일"
+            android:textColor="@color/main_purple"
+            android:textSize="20sp"
+            app:layout_constraintStart_toStartOf="@id/cl_date_info_container"
+            app:layout_constraintTop_toTopOf="@id/cl_date_info_container" />
+
+        <TextView
+            android:id="@+id/tv_daily"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:fontFamily="@font/suite_semi_bold"
+            android:text=" 하루 일기"
+            android:textColor="@color/black"
+            android:textSize="20sp"
+            app:layout_constraintStart_toEndOf="@id/tv_date"
+            app:layout_constraintTop_toTopOf="@id/cl_date_info_container" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <View
+        android:id="@+id/v_spacer"
+        android:layout_width="match_parent"
+        android:layout_height="31dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/cl_date_info_container" />
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/card_character_background"
+        android:layout_width="122dp"
+        android:layout_height="122dp"
+        android:layout_margin="8dp"
+        android:backgroundTint="@color/white"
+        app:cardCornerRadius="61dp"
+        app:cardElevation="8dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/v_spacer">
+
+        <!--    캐릭터 배치     -->
+    </com.google.android.material.card.MaterialCardView>
+
+    <TextView
+        android:id="@+id/tv_instruction"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="38dp"
+        android:fontFamily="@font/suite_regular"
+        android:text="100자 이내의 짧은 일기를 남겨봐요!"
+        android:textColor="@color/gray4"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/card_character_background" />
+
+    <EditText
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingHorizontal="45dp"
+        android:minHeight="178dp"
+        android:background="@drawable/et_diary_background"
+        android:text="아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아"
+        android:textColor="@color/main_purple"
+        android:textSize="14sp"
+        android:gravity="center"
+        android:lineSpacingExtra="12.dp"
+        app:layout_constraintTop_toBottomOf="@id/tv_instruction"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginTop="10dp"
+        />
+
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_do_it_daily_record.xml
+++ b/app/src/main/res/layout/fragment_do_it_daily_record.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_do_it_daily_record.xml
+++ b/app/src/main/res/layout/fragment_do_it_daily_record.xml
@@ -1,6 +1,177 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:background="#FAFAFA"
+    android:paddingHorizontal="16dp">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/cl_date_info_container"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <TextView
+            android:id="@+id/tv_date"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:fontFamily="@font/suite_bold"
+            android:text="11월 28일"
+            android:textColor="@color/main_purple"
+            android:textSize="20sp"
+            app:layout_constraintStart_toStartOf="@id/cl_date_info_container"
+            app:layout_constraintTop_toTopOf="@id/cl_date_info_container" />
+
+        <TextView
+            android:id="@+id/tv_daily"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:fontFamily="@font/suite_semi_bold"
+            android:text=" 하루 일기"
+            android:textColor="@color/black"
+            android:textSize="20sp"
+            app:layout_constraintStart_toEndOf="@id/tv_date"
+            app:layout_constraintTop_toTopOf="@id/cl_date_info_container" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/card_character_background"
+        android:layout_width="122dp"
+        android:layout_height="122dp"
+        android:layout_marginTop="31dp"
+        android:backgroundTint="@color/white"
+        app:cardCornerRadius="61dp"
+        app:cardElevation="8dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/cl_date_info_container">
+
+        <!--    캐릭터 배치     -->
+
+    </com.google.android.material.card.MaterialCardView>
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/card_mong_chat_record"
+        android:layout_width="match_parent"
+        android:layout_height="93dp"
+        android:layout_marginTop="40dp"
+        android:backgroundTint="@color/white"
+        app:cardCornerRadius="16dp"
+        app:cardElevation="8dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/card_character_background">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/cl_mong_chat_record"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:paddingHorizontal="15dp"
+            android:paddingVertical="10.dp">
+
+            <TextView
+                android:id="@+id/tv_see_mong_chat_record"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:fontFamily="@font/suite_bold"
+                android:text="쿠쿠몽과의 대화 보기"
+                android:textColor="@color/black"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="10dp"
+                android:fontFamily="@font/suite_medium"
+                android:text="지금까지 함께한 몽과의 대화를 볼 수 있어요!"
+                android:textColor="@color/gray3"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/tv_see_mong_chat_record" />
+
+            <ImageView
+                android:id="@+id/iv_mong_arrow"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:contentDescription="arrow"
+                android:src="@drawable/ic_do_it_record_arrow_gray2"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </com.google.android.material.card.MaterialCardView>
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/card_ai_chat_record"
+        android:layout_width="match_parent"
+        android:layout_height="93dp"
+        android:layout_marginTop="40dp"
+        android:backgroundTint="@color/white"
+        app:cardCornerRadius="16dp"
+        app:cardElevation="8dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/card_mong_chat_record">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/cl_ai_chat_record"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:paddingHorizontal="15dp"
+            android:paddingVertical="10.dp">
+
+            <TextView
+                android:id="@+id/tv_see_ai_chat_record"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:fontFamily="@font/suite_bold"
+                android:text="바둑이와의 상담 채팅 보기"
+                android:textColor="@color/black"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="10dp"
+                android:fontFamily="@font/suite_medium"
+                android:text="AI 상담가 바둑이와의 상담"
+                android:textColor="@color/gray3"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/tv_see_ai_chat_record" />
+
+            <ImageView
+                android:id="@+id/iv_ai_arrow"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:contentDescription="arrow"
+                android:src="@drawable/ic_do_it_record_arrow_gray2"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </com.google.android.material.card.MaterialCardView>
+
+    <Button
+        android:id="@+id/btn_see_record"
+        style="@style/CustomButtonStyle"
+        android:layout_width="173dp"
+        android:layout_height="48dp"
+        android:layout_marginTop="45dp"
+        android:background="@drawable/btn_bg_8_white_purple"
+        android:backgroundTint="@null"
+        android:drawableLeft="@drawable/ic_doit_archive"
+        android:paddingHorizontal="30dp"
+        android:text="기록 조회"
+        android:textColor="@color/main_purple"
+        android:textSize="16sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/card_ai_chat_record" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_do_it_monthly_record.xml
+++ b/app/src/main/res/layout/fragment_do_it_monthly_record.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_do_it_monthly_record.xml
+++ b/app/src/main/res/layout/fragment_do_it_monthly_record.xml
@@ -1,6 +1,67 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:background="#FAFAFA"
+    android:paddingHorizontal="16dp"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
+
+
+    <ImageButton
+        android:layout_width="30dp"
+        android:layout_height="20dp"
+        android:background="@drawable/btn_bg_16_white"
+        android:backgroundTint="@null"
+        android:src="@drawable/ic_do_it_record_arrow_gray2"
+        android:rotation="180"
+        android:contentDescription="left arrow"
+        android:layout_marginTop="20dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        />
+
+    <ImageButton
+        android:layout_width="30dp"
+        android:layout_height="20dp"
+        android:background="@drawable/btn_bg_16_white"
+        android:backgroundTint="@null"
+        android:src="@drawable/ic_do_it_record_arrow_gray2"
+        android:contentDescription="right arrow"
+        android:layout_marginTop="20dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        />
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/cl_date_info_container"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="20dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <TextView
+            android:id="@+id/tv_date"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:fontFamily="@font/suite_bold"
+            android:text="11월 28일"
+            android:textColor="@color/main_purple"
+            android:textSize="20sp"
+            app:layout_constraintStart_toStartOf="@id/cl_date_info_container"
+            app:layout_constraintTop_toTopOf="@id/cl_date_info_container" />
+
+        <TextView
+            android:id="@+id/tv_daily"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:fontFamily="@font/suite_semi_bold"
+            android:text=" 하루 일기"
+            android:textColor="@color/black"
+            android:textSize="20sp"
+            app:layout_constraintStart_toEndOf="@id/tv_date"
+            app:layout_constraintTop_toTopOf="@id/cl_date_info_container" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <style name="Theme.Durymong" parent="Theme.MaterialComponents.Light.NoActionBar" />
+
+    <style name="CustomButtonStyle" parent="Widget.AppCompat.Button">
+        <item name="backgroundTint">@null</item>
+    </style>
 </resources>


### PR DESCRIPTION
## 변경 사항 요약
5-3, 5-4에 해당하는 화면 기본 ui 구성

## 변경 사항

fragment_do_it_daily_diary.xml (5-4화면)
<img width="407" alt="image" src="https://github.com/user-attachments/assets/5fa331d6-d00d-4889-89d6-cd397b8fa1c5" />

- [x] 텍스트 입력 필드 제작, 우선은 크기가 자동으로 늘어나게 설정해두었음, 기능 구현시에 글자 수 제한을 넣을 예정이고 임의로 100글자 분량의 텍스트를 넣어두었음
- [x] 캐릭터 뒤에 들어갈 원형 컴포넌트 제작, 그림자는 기능 구현시에 수정할 예정

fragment_do_it_daily_record (5-3 화면)
<img width="307" alt="image" src="https://github.com/user-attachments/assets/6023fc6e-7e84-4916-a0a2-63d4eaebf93c" />

- [x] 쿠쿠몽, 바둑이와의 대화 기록을 조회하는 card 컴포넌트 제작, 그림자는 기능 구현시에 수정할 예정
- [x] 기록조회를 위한 버튼 생성, background로 지정할 btn_bg_8_white_purple.xml을 작성하였음



## 연관된 issue 번호(#issue번호 or fixes #issue번호)
merge시에 issue가 해결되면 fixes와 함께 작성
- #5 
- resolves #6 #7 


## 참고사항 (이미지/동영상 등 필요시 첨부)
- 탑앱바는 공통으로 묶을지 의논
- 캐릭터는 기능 구현시에 추가할 예정
